### PR TITLE
Detect changes seems to not work if all changes are added to the index

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,9 @@ jobs:
 
 ## Workflow:
 
-1. evaluate the `updateScript` setting (a bash string)
-2. If the `applyUpdateScript` setting is provided:
-   - Stage all changes from the `updateScript` step, so that they don't count as changes
-   - Evaluate the `applyUpdateScript` setting
-3. If there are no unstaged git changes or errors, the action terminates successfully (nothing to do)
+1. If the `setupScript` input is declared. Evaluate the `setupScript` (a bash string), all changes are staged, and will be ignored when detecting changes, but will be included in the final commit.
+2. evaluate the `updateScript` setting (a bash string)
+3. Detect if there are no unstaged git changes or errors, the action terminates successfully (nothing to do)
 4. commit to the branch specified in `branchName` setting, and **force push** to `origin`
 5. Search for open PRs for this branch
    - If none are found, create one (against the `baseBranch` setting, defaulting to the original checked-out branch)


### PR DESCRIPTION
`git add` adds the changed files to the index

Then `diff-files` diffs changes between the working tree and the index, there should be no changes if all the changes are correctly staged.

This PR changes the detect changes method so it instead diffs the contents of the index with the repository.  So if there are staged changes, it will detect them.

I have also exposed the repo and owner, since it's useful so we can update repositories other than ourselves 