### PR TITLE
Accept repository argument

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,7 @@ name: 'Self-update'
 description: 'Automate the creation of update pull requests'
 inputs:
   GITHUB_TOKEN: { "description": 'TODO', required: true }
+  repository: { "description": 'The GitHub repository in the form owner/repo defaults to GITHUB_REPOSITORY', required: false }
   authorName: { "description": 'TODO', required: false }
   authorEmail: { "description": 'TODO', required: false }
   updateScript: { "description": 'TODO', required: true }

--- a/out/lib.js
+++ b/out/lib.js
@@ -43,6 +43,7 @@ function parseSettings(inputs) {
     const repositoryFromEnv = (process.env['GITHUB_REPOSITORY'] || "").split('/');
     return {
         githubToken: get('GITHUB_TOKEN'),
+        githubRepository: process.env['GITHUB_REPOSITORY'] || "",
         owner: get('owner', repositoryFromEnv[0]),
         repo: get('repo', repositoryFromEnv[1]),
         updateScript: get('updateScript'),
@@ -260,7 +261,7 @@ function censorSecrets(log, settings) {
 }
 function renderPRDescription(state, settings) {
     const commit = state.commit || "(unknown commit)";
-    const runUrl = `https://github.com/${settings.owner}/${settings.repo}/actions/runs/${settings.runId}`;
+    const runUrl = `https://github.com/${settings.githubRepository}/actions/runs/${settings.runId}`;
     const outputHeader = (state.hasError
         ? ":no_entry_sign: Update failed"
         : ":white_check_mark: Update succeeded");

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -14,6 +14,7 @@ type State = {
 
 type Settings = {
   githubToken: string,
+  githubRepository: string,
   owner: string,
   repo: string,
   updateScript: string,
@@ -59,6 +60,7 @@ export function parseSettings(inputs: Record<string, string>): Settings {
 
   return {
     githubToken: get('GITHUB_TOKEN'),
+    githubRepository: process.env['GITHUB_REPOSITORY'] || "",
     owner: get('owner', repositoryFromEnv[0]),
     repo: get('repo', repositoryFromEnv[1]),
     updateScript: get('updateScript'),
@@ -301,7 +303,7 @@ function censorSecrets(log: Array<string>, settings: Settings): Array<string> {
 
 function renderPRDescription(state: State, settings: Settings): string {
   const commit = state.commit || "(unknown commit)"
-  const runUrl = `https://github.com/${settings.owner}/${settings.repo}/actions/runs/${settings.runId}`
+  const runUrl = `https://github.com/${settings.githubRepository}/actions/runs/${settings.runId}`
   const outputHeader = (state.hasError
     ? ":no_entry_sign: Update failed"
     : ":white_check_mark: Update succeeded"


### PR DESCRIPTION
The checkout action and others allow specifying the repository in the form `owner/repo` as the input `repository`. This PR aims to add the same functionality here.

 To make things work correctly though we need to store 2 values of repo, because the repository the action is hosted in won't always match the value passed in via `repository`.

From my experiments it's not possible to set the `GITHUB_REPOSITORY` directly for this action, so it will always point to the repository that hosts the workflow the action is used in.