### PR TITLE
Change repoId to use ID! type

### DIFF
--- a/out/lib.js
+++ b/out/lib.js
@@ -206,7 +206,7 @@ function createPR(state, settings, octokit) {
       $baseBranch: String!,
       $body: String!,
       $title: String!,
-      $repoId: String!
+      $repoId: ID!
     ) {
       createPullRequest(input: {
         repositoryId: $repoId,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -247,7 +247,7 @@ async function createPR(state: State, settings: Settings, octokit: Octokit): Pro
       $baseBranch: String!,
       $body: String!,
       $title: String!,
-      $repoId: String!
+      $repoId: ID!
     ) {
       createPullRequest(input: {
         repositoryId: $repoId,


### PR DESCRIPTION
This fixes the below error

```
::error::Type mismatch on variable $repoId and argument repositoryId (String! / ID!)
```

Tested by running the action locally like below:

```
env GITHUB_RUN_ID=$RANDOM INPUT_OWNER=zendesk INPUT_REPO=guide-truth-service INPUT_GITHUB_TOKEN=$GITHUB_TOKEN INPUT_BRANCHNAME=self-update-action-test INPUT_COMMITMESSAGE="Test self-update" INPUT_PRBODY="Bumping test ..." INPUT_PRTITLE="[cicd-toolkit-upgrade] test" GITHUB_REPOSITORY=zendesk/guide-truth-service INPUT_UPDATESCRIPT="cd cicd-toolkit; ./scripts/self-update.sh; make" node ~/Code/zendesk/self-update-action/action.js
```

Which created https://github.com/zendesk/guide-truth-service/pull/103