### PR TITLE
add prBodyHideOutput to metadata file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,7 @@ inputs:
   commitMessage: { "description": 'Commit message', required: false }
   prTitle: { "description": 'PR title', required: false }
   prBody: { "description": 'PR body', required: false }
+  prBodyHideOutput: { "description": "Don't show detailed output in PR body. Default: false", required: false }
 
 outputs:
   pr_number:


### PR DESCRIPTION
Follow up to https://github.com/timbertson/self-update-action/pull/23 

Need to add the new setting to the metadata file `action.yml`. The action currently still runs successfully, it just gives this warning message:

```
Warning: Unexpected input(s) 'prBodyHideOutput', valid inputs are ['GITHUB_TOKEN', 'repository', 'authorName', 'authorEmail', 'setupScript', 'updateScript', 'branchName', 'baseBranch', 'commitMessage', 'prTitle', 'prBody']
```

@timbertson 
